### PR TITLE
Links in documentation

### DIFF
--- a/lib/JSON/JQ.pm
+++ b/lib/JSON/JQ.pm
@@ -226,7 +226,7 @@ B<Internal use only>. When on, print out debug messages from XS code.
 
 =head1 BUGS
 
-Please report bugs to https://github.com/dxma/perl5-json-jq/issues
+Please report bugs to L<https://github.com/dxma/perl5-json-jq/issues>.
 
 =head1 AUTHOR
 
@@ -247,7 +247,11 @@ LICENSE file included with this module.
 
 =head1 SEE ALSO
 
-   * L<jq official wiki|https://github.com/stedolan/jq/wiki>
+=over
+
+=item L<jq official wiki|https://github.com/stedolan/jq/wiki>
+
+=back
 
 =cut
 


### PR DESCRIPTION
This changes the final see also to POD rather than Markdown format and adds a link around the bug tracker.
