### PR TITLE
use "long" (64 bits) for integer representation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ inc/
 /pm_to_blib
 /*.zip
 
+.vscode/
+
 .vstags
 /lib/**/*.c
 /lib/**/*.o

--- a/lib/JSON/JQ.xs
+++ b/lib/JSON/JQ.xs
@@ -45,11 +45,11 @@ jv my_jv_input(pTHX_ void * arg) {
     }
     else if (SvIOK(p_sv)) {
         // integer
-        return jv_number((int)SvIV(p_sv));
+        return jv_number((long)SvIV(p_sv));
     }
     else if (SvUOK(p_sv)) {
         // unsigned int
-        return jv_number((unsigned int)SvUV(p_sv));
+        return jv_number((unsigned long)SvUV(p_sv));
     }
     else if (SvNOK(p_sv)) {
         // double
@@ -121,7 +121,7 @@ void * my_jv_output(pTHX_ jv jval) {
         double val = jv_number_value(jval);
         SV * p_sv = newSV(0);
         if (jv_is_integer(jval)) {
-            sv_setiv(p_sv, (int)val);
+            sv_setiv(p_sv, (long)val);
         }
         else {
             sv_setnv(p_sv, val);

--- a/t/integer_representation.t
+++ b/t/integer_representation.t
@@ -1,0 +1,12 @@
+# -*- perl -*-
+use Test::More tests => 1;
+
+use strict;
+use warnings;
+
+use JSON::JQ;
+
+my $jq = JSON::JQ->new({ script => '.' });
+my $input = 1651546351000;
+my $expected = 1651546351000;
+is(${$jq->process({ data => $input })}[0], $expected, 'integer representation');


### PR DESCRIPTION
This is a fix for https://github.com/dxma/perl5-json-jq/issues/11#issue-1174237645

