### PR TITLE
Wrap `use FindBin` et al in an "eval"

### DIFF
--- a/lib/JSON/JQ.pm
+++ b/lib/JSON/JQ.pm
@@ -8,8 +8,8 @@ our $VERSION = '0.09';
 our $DEBUG       = 0;
 our $DUMP_DISASM = 0;
 
-use FindBin ();
-FindBin::again();
+BEGIN { eval "use FindBin ()" }
+eval "FindBin::again()";
 use POSIX qw/isatty/;
 use Path::Tiny qw/path/;
 use JSON qw/from_json/;


### PR DESCRIPTION
I know it might seem a little pathological, but FindBin can die if its script is coming via named pipe:
```
  _PERL='use Data::Dumper; print Dumper( JSON::JQ->new({ script => "." })->process({json => <>}) )'
  echo '{"one": 1, "two": 2}' | perl -MJSON::JQ -0777 <(echo "$_PERL")

  Cannot find current script '/dev/fd/63' at /System/Library/Perl/5.30/FindBin.pm line 166.
  BEGIN failed--compilation aborted at /System/Library/Perl/5.30/FindBin.pm line 166.
```

(I use this technique to generate much more complex query scripts on the fly, for example...)