### PR TITLE
Add optional unicode character mode

### DIFF
--- a/lib/JSON/JQ.pm
+++ b/lib/JSON/JQ.pm
@@ -39,6 +39,8 @@ sub new {
     $self->{_attribute}->{PROGRAM_ORIGIN} = exists $param->{script_file} ? path($param->{script_file})->parent->stringify : '.';
     # error callback will push error messages into this array
     $self->{_errors} = [];
+    # unicode flag
+    $self->{unicode} = !!$param->{unicode};
     # debug callback print flags
     my $dump_opts = JV_PRINT_INDENT_FLAGS(2);
     $dump_opts |= JV_PRINT_SORTED;
@@ -134,6 +136,12 @@ A hash reference with pre-defined variables and their values, they can be used b
 later. Complex data structures like nested arrays and/or hashes are acceptable.
 
 Check the jq official documentation on how to reference variables inside script.
+
+=item * unicode
+
+A boolean indicating whether strings in the data (including hash keys)
+are treated as Unicode character strings.  The default is false, which
+means that strings are treated as UTF-8 byte strings.
 
 =item * library_paths
 

--- a/lib/JSON/JQ.xs
+++ b/lib/JSON/JQ.xs
@@ -158,7 +158,7 @@ void * my_jv_output(pTHX_ jv jval) {
             if (jv_get_kind(key) != JV_KIND_STRING) {
                 croak("cannot take non-string type as hash key: JV_KIND == %i", jv_get_kind(key));
             }
-            const char * k = jv_string_value(key);
+            const char * k = jv_string_value(jv_copy(key));
             int klen = jv_string_length_bytes(key);
             SV * v = (SV *)my_jv_output(aTHX_ val);
             hv_store(p_hv, k, klen, v, 0);
@@ -178,7 +178,7 @@ static void my_error_cb(void * errors, jv jerr) {
     dTHX;
     // original jerr will be freed by jq engine
     jerr = jv_copy(jerr);
-    av_push((AV *)errors, newSVpvn(jv_string_value(jerr), jv_string_length_bytes(jerr)));
+    av_push((AV *)errors, newSVpvn(jv_string_value(jerr), jv_string_length_bytes(jv_copy(jerr))));
 }
 
 static void my_debug_cb(void * data, jv input) {

--- a/lib/JSON/JQ.xs
+++ b/lib/JSON/JQ.xs
@@ -24,7 +24,7 @@
 
 // utility functions for type marshaling
 // they are not XS code
-jv my_jv_input(pTHX_ void * arg) {
+jv my_jv_input(pTHX_ void * arg, bool unicode) {
     if (arg == NULL) {
         return jv_null();
     }
@@ -58,7 +58,7 @@ jv my_jv_input(pTHX_ void * arg) {
     else if (SvPOK(p_sv)) {
         // string
         STRLEN len;
-        char * p_pv = SvUTF8(p_sv) ? SvPVutf8(p_sv, len) : SvPV(p_sv, len);
+        char * p_pv = unicode ? SvPVutf8(p_sv, len) : SvPV(p_sv, len);
         //fprintf(stderr, "my_jv_input() got string: %s\n", p_pv);
         return jv_string_sized(p_pv, len);
     }
@@ -72,7 +72,7 @@ jv my_jv_input(pTHX_ void * arg) {
         }
         SSize_t i;
         for (i = 0; i <= len; i++) {
-            jval = jv_array_append(jval, my_jv_input(aTHX_ *av_fetch(p_av, i, 0)));
+            jval = jv_array_append(jval, my_jv_input(aTHX_ *av_fetch(p_av, i, 0), unicode));
         }
         return jval;
     }
@@ -83,10 +83,15 @@ jv my_jv_input(pTHX_ void * arg) {
         I32 len = hv_iterinit(p_hv);
         I32 i;
         for (i = 0; i < len; i++) {
-            char * key = NULL;
-            I32 klen = 0;
-            SV * val = hv_iternextsv(p_hv, &key, &klen);
-            jval = jv_object_set(jval, jv_string_sized(key, klen), my_jv_input(aTHX_ val));
+            HE * he = hv_iternext(p_hv);
+            STRLEN klen;
+            char * key = HePV(he, klen);
+            SV * val = HeVAL(he);
+            if (unicode && !HeUTF8(he))
+                key = bytes_to_utf8(key, &klen);
+            jval = jv_object_set(jval, jv_string_sized(key, klen), my_jv_input(aTHX_ val, unicode));
+            if (unicode && !HeUTF8(he))
+                Safefree(key);
         }
         return jval;
     }
@@ -97,7 +102,7 @@ jv my_jv_input(pTHX_ void * arg) {
     // NOREACH
 }
 
-void * my_jv_output(pTHX_ jv jval) {
+void * my_jv_output(pTHX_ jv jval, bool unicode) {
     jv_kind kind = jv_get_kind(jval);
     if (kind == JV_KIND_NULL) {
         // null
@@ -130,10 +135,7 @@ void * my_jv_output(pTHX_ jv jval) {
     }
     else if (kind == JV_KIND_STRING) {
         // string
-        //fprintf(stderr, "my_jv_output() got string: %s\n", jv_string_value(jval));
-        //return newSVpvn(jv_string_value(jval), jv_string_length_bytes(jval));
-        // NOTE: this might introduce unicode bug..
-        return newSVpvf("%s", jv_string_value(jval));
+        return newSVpvn_utf8(jv_string_value(jval), jv_string_length_bytes(jv_copy(jval)), unicode);
     }
     else if (kind == JV_KIND_ARRAY) {
         // array
@@ -143,7 +145,7 @@ void * my_jv_output(pTHX_ jv jval) {
         SSize_t i;
         for (i = 0; i < len; i++) {
             jv val = jv_array_get(jv_copy(jval), i);
-            av_push(p_av, (SV *)my_jv_output(aTHX_ val));
+            av_push(p_av, (SV *)my_jv_output(aTHX_ val, unicode));
             jv_free(val);
         }
         return newRV_noinc((SV *)p_av);
@@ -160,8 +162,8 @@ void * my_jv_output(pTHX_ jv jval) {
             }
             const char * k = jv_string_value(jv_copy(key));
             int klen = jv_string_length_bytes(key);
-            SV * v = (SV *)my_jv_output(aTHX_ val);
-            hv_store(p_hv, k, klen, v, 0);
+            SV * v = (SV *)my_jv_output(aTHX_ val, unicode);
+            hv_store(p_hv, k, unicode ? -klen : klen, v, 0);
             jv_free(key);
             jv_free(val);
             iter = jv_object_iter_next(jval, iter);
@@ -245,6 +247,7 @@ _init(self)
             SvREADONLY_on(sv_jq);
             hv_stores(self, "_jq", sv_jq);
         }
+        bool unicode = SvTRUE(*hv_fetchs(self, "unicode", 0));
         // step 2. set error and debug callbacks
         av_err = (AV *)SvRV(*hv_fetchs(self, "_errors", 0));
         jq_set_error_cb(_jq, my_error_cb, av_err);
@@ -255,15 +258,20 @@ _init(self)
         I32 len = hv_iterinit(hv_attr);
         I32 i;
         for (i = 0; i < len; i++) {
-            char * key = NULL;
-            I32 klen = 0;
-            SV * val = hv_iternextsv(hv_attr, &key, &klen);
-            jq_set_attr(_jq, jv_string_sized(key, klen), my_jv_input(aTHX_ val));
+            HE * he = hv_iternext(hv_attr);
+            STRLEN klen;
+            char * key = HePV(he, klen);
+            SV * val = HeVAL(he);
+            if (unicode && !HeUTF8(he))
+                key = bytes_to_utf8(key, &klen);
+            jq_set_attr(_jq, jv_string_sized(key, klen), my_jv_input(aTHX_ val, unicode));
+            if (unicode && !HeUTF8(he))
+                Safefree(key);
         }
         // set JQ_VERSION
         jq_set_attr(_jq, jv_string("VERSION_DIR"), jv_string(JQ_VERSION));
         // step 4. compile
-        jv args = my_jv_input(aTHX_ *hv_fetchs(self, "variable", 0));
+        jv args = my_jv_input(aTHX_ *hv_fetchs(self, "variable", 0), unicode);
         if (hv_exists(self, "script_file", 11)) {
             jv data = jv_load_file(SvPV_nolen(*hv_fetchs(self, "script_file", 0)), 1);
             if (!jv_is_valid(data)) {
@@ -307,7 +315,8 @@ _process(self, sv_input, av_output)
         assert_isa(aTHX_ ST(0));
         sv_jq = *hv_fetchs(self, "_jq", 0);
         _jq = INT2PTR(jq_state *, SvIV(sv_jq));
-        jv jv_input = my_jv_input(aTHX_ sv_input);
+        bool unicode = SvTRUE(*hv_fetchs(self, "unicode", 0));
+        jv jv_input = my_jv_input(aTHX_ sv_input, unicode);
         int jq_flags = (int)SvIV(*hv_fetchs(self, "jq_flags", 0));
         // logic from process() in main.c
         jq_start(_jq, jv_input, jq_flags);
@@ -317,7 +326,7 @@ _process(self, sv_input, av_output)
         av_clear(av_err);
         int ret = 14;
         while (jv_is_valid(result = jq_next(_jq))) {
-            av_push(av_output, (SV *)my_jv_output(aTHX_ result));
+            av_push(av_output, (SV *)my_jv_output(aTHX_ result, unicode));
             if (jv_get_kind(result) == JV_KIND_FALSE || jv_get_kind(result) == JV_KIND_NULL) {
                 ret = 11;
             }

--- a/t/007_unicode.t
+++ b/t/007_unicode.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use utf8;
+use open qw(:std :encoding(utf8));
+
+use Test::More tests => 2;
+
+use JSON::JQ;
+
+my $jq = JSON::JQ->new({ script => '.', unicode => 1 });
+
+utf8::downgrade(my $latin1_down = "døwn");
+utf8::upgrade(my $latin1_up = "üp");
+my $emoji = "\N{SNOWMAN}";
+
+my $data = {
+    map +(
+         $_ => {
+             scalar => $_,
+             array => [ $_ ],
+         }
+     ), $latin1_down, $latin1_up, $emoji
+};
+
+is_deeply($jq->process({ data => $data }), $data,
+          'unicode data roundtrip');
+
+my $jq2 = JSON::JQ->new({ script => '.[] | .[1:2]', unicode => 1});
+
+my $data2 = [ $latin1_up, $latin1_down, "u$emoji" ];
+is_deeply([$jq2->process({ data => $data2 })],
+          [ map substr($_, 1, 1), @$data2 ],
+          'unicode character offsets');


### PR DESCRIPTION
This causes the module to treat all strings (including hash keys) in
the data as Unicode character strings, rather tha UTF-8 byte strings.